### PR TITLE
Fix IndexError when message key is empty

### DIFF
--- a/processout/networking/response.py
+++ b/processout/networking/response.py
@@ -65,7 +65,7 @@ class Response:
     def message(self):
         """Get the response error message"""
         message = ""
-        if self.body["message"] != None:
+        if self.body.get("message") != None:
             message = message + self.body["message"]
 
         return message


### PR DESCRIPTION
If the `message` variable is empty, it raises an IndexError.

I had the issue with a `'card.failed-3ds'` transaction.